### PR TITLE
fix Containerfile path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ compile:
 
 build:
 	@echo "### [Building project's docker image] ###"
-	@$(CONTAINER_ENGINE) build -t $(CONSOLE_IMAGE):latest -f ./Dockerfile .
+	@$(CONTAINER_ENGINE) build -t $(CONSOLE_IMAGE):latest -f ./Containerfile .
 	@$(CONTAINER_ENGINE) tag $(CONSOLE_IMAGE):latest $(CONSOLE_IMAGE):${VERSION}
 	@$(CONTAINER_ENGINE) tag $(CONSOLE_IMAGE):latest $(CONSOLE_IMAGE):${IMAGE_TAG}
 	@echo "Build Successful"


### PR DESCRIPTION
Solve the build issue

```shell
make build
### [Building project's docker image] ###
[+] Building 0.1s (1/1) FINISHED                                                                                       docker:default
 => [internal] load build definition from Dockerfile                                                                             0.0s
 => => transferring dockerfile: 2B                                                                                               0.0s
ERROR: failed to solve: failed to read dockerfile: open Dockerfile: no such file or directory
make: *** [Makefile:35: build] Error 1
```