### PR TITLE
fix: update Node.js container image to address security vulnerabilities

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,7 @@
 ## Run
 ####################
 # Obtained from: https://catalog.redhat.com/software/containers/ubi9/nodejs-18/62e8e7ed22d1d3c2dfe2ca01?container-tabs=gti
-FROM registry.access.redhat.com/ubi9/nodejs-18:1-59.1690899127
+FROM registry.access.redhat.com/ubi9/nodejs-18:9.5-1733148761
 
 # Labels
 LABEL VERSION="v0.2"


### PR DESCRIPTION
Node.js container image updated to the latest available version

Closes #29 