### PR TITLE
fix: ensure unique keys for child components to resolve React warning

### DIFF
--- a/src/app/AccountDetails/AccountDetails.tsx
+++ b/src/app/AccountDetails/AccountDetails.tsx
@@ -1,6 +1,6 @@
-import { parseScanTimestamp, parseNumberToCurrency, } from 'src/app/utils/parseFuncs';
-import { renderStatusLabel } from "src/app/utils/renderStatusLabel";
-import React, { useEffect, useState } from "react";
+import { parseScanTimestamp, parseNumberToCurrency } from 'src/app/utils/parseFuncs';
+import { renderStatusLabel } from 'src/app/utils/renderStatusLabel';
+import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import {
   PageSection,
@@ -19,84 +19,69 @@ import {
   Flex,
   FlexItem,
   Page,
-  Spinner,
-} from "@patternfly/react-core";
-import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
-import { getAccountByName, getAccountClusters } from "../services/api";
-import { Link  } from "react-router-dom";
-import { AccountData, Cluster } from "@app/types/types";
-import { useLocation  } from "react-router-dom";
-interface LabelGroupOverflowProps {
-  labels: {
-    text: string;
-  }[];
-}
+} from '@patternfly/react-core';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { getAccountByName, getAccountClusters } from '../services/api';
+import { Link } from 'react-router-dom';
+import { AccountData, Cluster } from '@app/types/types';
+import { LoadingSpinner } from '../components/common/LoadingSpinner';
 
+const columnNames = {
+  id: 'ID',
+  name: 'Name',
+  status: 'Status',
+  cloudProvider: 'Cloud Provider',
+  instanceCount: 'Instance Count',
+};
 
 const AggregateClustersPerAccount: React.FunctionComponent = () => {
   const [data, setData] = useState<Cluster[] | []>([]);
   const [loading, setLoading] = useState(true);
   const { accountName } = useParams();
 
-
   useEffect(() => {
     const fetchData = async () => {
       try {
-          console.log("Fetching data...");
-          const fetchedAccountClusters = await getAccountClusters(accountName);
-          console.log("Fetched Account data:", fetchedAccountClusters);
-          setData(fetchedAccountClusters);
+        console.log('Fetching data...');
+        const fetchedAccountClusters = await getAccountClusters(accountName);
+        console.log('Fetched Account data:', fetchedAccountClusters);
+        setData(fetchedAccountClusters);
       } catch (error) {
-        console.error("Error fetching data:", error);
+        console.error('Error fetching data:', error);
       } finally {
         setLoading(false);
       }
     };
 
     fetchData();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  console.log("Rendered with data:", data);
+  console.log('Rendered with data:', data);
 
   return (
     <React.Fragment>
       {loading ? (
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "center",
-            alignItems: "center",
-            height: "100vh",
-          }}
-        >
-          <Spinner size="xl" />
-        </div>
+        <LoadingSpinner />
       ) : (
         <Table aria-label="Simple table">
           <Thead>
             <Tr>
-              <Th>ID</Th>
-              <Th>Name</Th>
-              <Th>Status</Th>
-              <Th>Provider</Th>
-              <Th>Instance Count</Th>
+              <Th>{columnNames.id}</Th>
+              <Th>{columnNames.name}</Th>
+              <Th>{columnNames.status}</Th>
+              <Th>{columnNames.cloudProvider}</Th>
+              <Th>{columnNames.instanceCount}</Th>
             </Tr>
           </Thead>
           <Tbody>
             {data.map((cluster) => (
-              <Tr key={cluster.name}>
+              <Tr key={cluster.id}>
                 <Td dataLabel={cluster.name}>
-                  <Link
-                    to={`/clusters/${cluster.id}`}
-                  >
-                    {cluster.id}
-                  </Link>
+                  <Link to={`/clusters/${cluster.id}`}>{cluster.id}</Link>
                 </Td>
                 <Td>{cluster.name}</Td>
-                <Td dataLabel={cluster.status}>
-                  {renderStatusLabel(cluster.status)}
-                </Td>
+                <Td dataLabel={cluster.status}>{renderStatusLabel(cluster.status)}</Td>
                 <Td>{cluster.provider}</Td>
                 <Td>{cluster.instanceCount}</Td>
               </Tr>
@@ -113,26 +98,25 @@ const AccountDetails: React.FunctionComponent = () => {
   const [activeTabKey, setActiveTabKey] = React.useState(0);
   const [accountData, setAccountData] = useState<AccountData>({
     count: 0,
-    accounts: []
+    accounts: [],
   });
   const [loading, setLoading] = useState(true);
-  const location = useLocation();
   useEffect(() => {
     const fetchData = async () => {
       try {
-          console.log("Fetching Account Clusters ", accountName);
-          const fetchedAccountClusters = await getAccountByName(accountName);
-          setAccountData(fetchedAccountClusters);
-          console.log("Fetched Account Clusters data:", accountData);
+        console.log('Fetching Account Clusters ', accountName);
+        const fetchedAccountClusters = await getAccountByName(accountName);
+        setAccountData(fetchedAccountClusters);
+        console.log('Fetched Account Clusters data:', accountData);
       } catch (error) {
-        console.error("Error fetching data:", error);
+        console.error('Error fetching data:', error);
       } finally {
         setLoading(false);
       }
     };
 
     fetchData();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleTabClick = (event, tabIndex) => {
@@ -140,74 +124,50 @@ const AccountDetails: React.FunctionComponent = () => {
   };
 
   const detailsTabContent = (
-
     <React.Fragment>
-    {loading ? (
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "center",
-          alignItems: "center",
-          height: "100vh",
-        }}
-      >
-        <Spinner size="xl" />
-      </div>
-    ) : 
-    (<Flex direction={{ default: "column" }}>
-      <FlexItem spacer={{ default: "spacerLg" }}>
-        <Title
-          headingLevel="h2"
-          size="lg"
-          className="pf-v5-u-mt-sm"
-          id="open-tabs-example-tabs-list-details-title"
-        >
-          Account details
-        </Title>
-      </FlexItem>
+      {loading ? (
+        <LoadingSpinner />
+      ) : (
+        <Flex direction={{ default: 'column' }}>
+          <FlexItem spacer={{ default: 'spacerLg' }}>
+            <Title headingLevel="h2" size="lg" className="pf-v5-u-mt-sm" id="open-tabs-example-tabs-list-details-title">
+              Account details
+            </Title>
+          </FlexItem>
 
-      <FlexItem>
-        <DescriptionList
-          columnModifier={{ lg: "2Col" }}
-          aria-labelledby="open-tabs-example-tabs-list-details-title"
-        >
-          <DescriptionListGroup>
-            <DescriptionListTerm>Name</DescriptionListTerm>
-            <DescriptionListDescription>
-              {accountData.accounts[0].name}
-            </DescriptionListDescription>
-            <DescriptionListTerm>Account ID</DescriptionListTerm>
-            <DescriptionListDescription>
-              {accountData.accounts[0].id}
-            </DescriptionListDescription>
-          </DescriptionListGroup>
-          <DescriptionListGroup>
-            <DescriptionListTerm>Cloud Provider</DescriptionListTerm>
-            <DescriptionListDescription>
-              {accountData.accounts[0].provider}
-            </DescriptionListDescription>
-            <DescriptionListTerm>Account Total Cost (Estimated)</DescriptionListTerm>
-            <DescriptionListDescription>
-              {parseNumberToCurrency(accountData.accounts[0].totalCost)}
-            </DescriptionListDescription>
-          </DescriptionListGroup>
-          <DescriptionListGroup>
-          </DescriptionListGroup>
-          <DescriptionListGroup>
-            <DescriptionListTerm>Last scanned at</DescriptionListTerm>
-            <DescriptionListDescription>
-              {parseScanTimestamp(accountData.accounts[0].lastScanTimestamp)}
-            </DescriptionListDescription>
-          </DescriptionListGroup>
-          <DescriptionListGroup>
-          </DescriptionListGroup>
-        </DescriptionList>
-      </FlexItem>
-    </Flex>)}
+          <FlexItem>
+            <DescriptionList
+              columnModifier={{ lg: '2Col' }}
+              aria-labelledby="open-tabs-example-tabs-list-details-title"
+            >
+              <DescriptionListGroup>
+                <DescriptionListTerm>Name</DescriptionListTerm>
+                <DescriptionListDescription>{accountData.accounts[0].name}</DescriptionListDescription>
+                <DescriptionListTerm>Account ID</DescriptionListTerm>
+                <DescriptionListDescription>{accountData.accounts[0].id}</DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Cloud Provider</DescriptionListTerm>
+                <DescriptionListDescription>{accountData.accounts[0].provider}</DescriptionListDescription>
+                <DescriptionListTerm>Account Total Cost (Estimated)</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {parseNumberToCurrency(accountData.accounts[0].totalCost)}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup></DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Last scanned at</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {parseScanTimestamp(accountData.accounts[0].lastScanTimestamp)}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup></DescriptionListGroup>
+            </DescriptionList>
+          </FlexItem>
+        </Flex>
+      )}
     </React.Fragment>
   );
-
-
 
   const clustersTabContent = (
     <TabContentBody>
@@ -215,19 +175,15 @@ const AccountDetails: React.FunctionComponent = () => {
     </TabContentBody>
   );
 
-
   return (
     <Page>
-
       {/* Page header */}
       <PageSection isWidthLimited variant={PageSectionVariants.light}>
-
         <Flex
-          spaceItems={{ default: "spaceItemsMd" }}
-          alignItems={{ default: "alignItemsFlexStart" }}
-          flexWrap={{ default: "nowrap" }}
+          spaceItems={{ default: 'spaceItemsMd' }}
+          alignItems={{ default: 'alignItemsFlexStart' }}
+          flexWrap={{ default: 'nowrap' }}
         >
-
           <FlexItem>
             <Label color="blue">Account</Label>
           </FlexItem>
@@ -236,51 +192,20 @@ const AccountDetails: React.FunctionComponent = () => {
               {accountName}
             </Title>
           </FlexItem>
-
-
         </Flex>
         {/* Page tabs */}
       </PageSection>
-      <PageSection
-        type="tabs"
-        variant={PageSectionVariants.light}
-        isWidthLimited
-      >
-        <Tabs
-          activeKey={activeTabKey}
-          onSelect={handleTabClick}
-          usePageInsets
-          id="open-tabs-example-tabs-list"
-        >
-          <Tab
-            eventKey={0}
-            title={<TabTitleText>Details</TabTitleText>}
-            tabContentId={`tabContent${0}`}
-          />
-          <Tab
-            eventKey={1}
-            title={<TabTitleText>Clusters</TabTitleText>}
-            tabContentId={`tabContent${1}`}
-          />
+      <PageSection type="tabs" variant={PageSectionVariants.light} isWidthLimited>
+        <Tabs activeKey={activeTabKey} onSelect={handleTabClick} usePageInsets id="open-tabs-example-tabs-list">
+          <Tab eventKey={0} title={<TabTitleText>Details</TabTitleText>} tabContentId={`tabContent${0}`} />
+          <Tab eventKey={1} title={<TabTitleText>Clusters</TabTitleText>} tabContentId={`tabContent${1}`} />
         </Tabs>
       </PageSection>
       <PageSection isWidthLimited variant={PageSectionVariants.light}>
-        <TabContent
-          key={0}
-          eventKey={0}
-          id={`tabContent${0}`}
-          activeKey={activeTabKey}
-          hidden={0 !== activeTabKey}
-        >
+        <TabContent key={0} eventKey={0} id={`tabContent${0}`} activeKey={activeTabKey} hidden={0 !== activeTabKey}>
           <TabContentBody>{detailsTabContent}</TabContentBody>
         </TabContent>
-        <TabContent
-          key={1}
-          eventKey={1}
-          id={`tabContent${1}`}
-          activeKey={activeTabKey}
-          hidden={1 !== activeTabKey}
-        >
+        <TabContent key={1} eventKey={1} id={`tabContent${1}`} activeKey={activeTabKey} hidden={1 !== activeTabKey}>
           <TabContentBody>{clustersTabContent}</TabContentBody>
         </TabContent>
       </PageSection>

--- a/src/app/components/common/LoadingSpinner.tsx
+++ b/src/app/components/common/LoadingSpinner.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Spinner } from '@patternfly/react-core';
+
+export const LoadingSpinner: React.FunctionComponent = () => (
+  <div
+    style={{
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      height: '100vh',
+    }}
+  >
+    <Spinner size="xl" />
+  </div>
+);


### PR DESCRIPTION
Fix React warning

```
hook.js:608
Warning: Encountered two children with the same key, `rhcl-dev01`.
Keys should be unique so that components maintain their identity across updates.
Non-unique keys may cause children to be duplicated and/or omitted — 
the behavior is unsupported and could change in a future version.
```