### PR TITLE
feat: refactor AccountDetails into smaller components

### DIFF
--- a/src/app/AccountDetails/components/AccountClusters.tsx
+++ b/src/app/AccountDetails/components/AccountClusters.tsx
@@ -1,0 +1,34 @@
+import { LoadingSpinner } from '@app/components/common/LoadingSpinner';
+import { Cluster } from '@app/types/types';
+import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { ClustersTable } from './ClustersTable';
+import { getAccountClusters } from '@app/services/api';
+import { debug } from '@app/utils/debugLogs';
+
+export const AccountClusters: React.FunctionComponent = () => {
+  const [data, setData] = useState<Cluster[] | []>([]);
+  const [loading, setLoading] = useState(true);
+  const { accountName } = useParams();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        debug('Fetching data...');
+        const fetchedAccountClusters = await getAccountClusters(accountName);
+        debug('Fetched Account data:', fetchedAccountClusters);
+        setData(fetchedAccountClusters);
+      } catch (error) {
+        console.error('Error fetching data:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [accountName]);
+
+  debug('Rendered with data:', data);
+
+  return <React.Fragment>{loading ? <LoadingSpinner /> : <ClustersTable clusters={data} />}</React.Fragment>;
+};

--- a/src/app/AccountDetails/components/AccountDescriptionList.tsx
+++ b/src/app/AccountDetails/components/AccountDescriptionList.tsx
@@ -1,0 +1,35 @@
+import { parseNumberToCurrency, parseScanTimestamp } from '@app/utils/parseFuncs';
+import {
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+} from '@patternfly/react-core';
+
+import { AccountDescriptionListProps } from './types';
+import React from 'react';
+
+export const AccountDescriptionList: React.FunctionComponent<AccountDescriptionListProps> = ({ account }) => {
+  return (
+    <DescriptionList columnModifier={{ lg: '2Col' }} aria-labelledby="open-tabs-example-tabs-list-details-title">
+      <DescriptionListGroup>
+        <DescriptionListTerm>Name</DescriptionListTerm>
+        <DescriptionListDescription>{account.name}</DescriptionListDescription>
+        <DescriptionListTerm>Account ID</DescriptionListTerm>
+        <DescriptionListDescription>{account.id}</DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Cloud Provider</DescriptionListTerm>
+        <DescriptionListDescription>{account.provider}</DescriptionListDescription>
+        <DescriptionListTerm>Account Total Cost (Estimated)</DescriptionListTerm>
+        <DescriptionListDescription>{parseNumberToCurrency(account.totalCost)}</DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup></DescriptionListGroup>
+      <DescriptionListGroup>
+        <DescriptionListTerm>Last scanned at</DescriptionListTerm>
+        <DescriptionListDescription>{parseScanTimestamp(account.lastScanTimestamp)}</DescriptionListDescription>
+      </DescriptionListGroup>
+      <DescriptionListGroup></DescriptionListGroup>
+    </DescriptionList>
+  );
+};

--- a/src/app/AccountDetails/components/AccountDetailsContent.tsx
+++ b/src/app/AccountDetails/components/AccountDetailsContent.tsx
@@ -1,0 +1,29 @@
+import { LoadingSpinner } from '@app/components/common/LoadingSpinner';
+import { Flex, FlexItem, Title } from '@patternfly/react-core';
+import React from 'react';
+import { AccountDetailsContentProps } from './types';
+import { AccountDescriptionList } from './AccountDescriptionList';
+
+export const AccountDetailsContent: React.FunctionComponent<AccountDetailsContentProps> = ({
+  loading,
+  accountData,
+}) => {
+  return (
+    <React.Fragment>
+      {loading ? (
+        <LoadingSpinner />
+      ) : (
+        <Flex direction={{ default: 'column' }}>
+          <FlexItem spacer={{ default: 'spacerLg' }}>
+            <Title headingLevel="h2" size="lg" className="pf-v5-u-mt-sm" id="open-tabs-example-tabs-list-details-title">
+              Account details
+            </Title>
+          </FlexItem>
+          <FlexItem>
+            <AccountDescriptionList account={accountData.accounts[0]} />
+          </FlexItem>
+        </Flex>
+      )}
+    </React.Fragment>
+  );
+};

--- a/src/app/AccountDetails/components/AccountHeader.tsx
+++ b/src/app/AccountDetails/components/AccountHeader.tsx
@@ -1,0 +1,26 @@
+import { Flex, FlexItem, Label, PageSection, PageSectionVariants, Title } from '@patternfly/react-core';
+import { AccountsHeaderProps } from './types';
+import React from 'react';
+
+export const AccountsHeader: React.FunctionComponent<AccountsHeaderProps> = ({ accountName, label }) => {
+  return (
+    <PageSection variant={PageSectionVariants.light}>
+      <Flex
+        spaceItems={{ default: 'spaceItemsMd' }}
+        alignItems={{ default: 'alignItemsFlexStart' }}
+        flexWrap={{ default: 'nowrap' }}
+      >
+        <FlexItem>
+          <Label color="blue">{label}</Label>
+        </FlexItem>
+        <FlexItem>
+          <Title headingLevel="h1" size="2xl">
+            {accountName}
+          </Title>
+        </FlexItem>
+      </Flex>
+    </PageSection>
+  );
+};
+
+export default AccountsHeader;

--- a/src/app/AccountDetails/components/AccountTabs.tsx
+++ b/src/app/AccountDetails/components/AccountTabs.tsx
@@ -1,0 +1,39 @@
+import {
+  PageSection,
+  PageSectionVariants,
+  Tab,
+  TabContent,
+  TabContentBody,
+  Tabs,
+  TabTitleText,
+} from '@patternfly/react-core';
+import React from 'react';
+import { AccountsTabsProps } from './types';
+
+export const AccountsTabs: React.FunctionComponent<AccountsTabsProps> = ({ detailsTabContent, clustersTabContent }) => {
+  const [activeTabKey, setActiveTabKey] = React.useState(0);
+  const handleTabClick = (_event: React.MouseEvent, eventKey: string | number) => {
+    setActiveTabKey(eventKey as number);
+  };
+
+  return (
+    <>
+      <PageSection type="tabs" variant={PageSectionVariants.light}>
+        <Tabs activeKey={activeTabKey} onSelect={handleTabClick} usePageInsets id="open-tabs-example-tabs-list">
+          <Tab eventKey={0} title={<TabTitleText>Details</TabTitleText>} tabContentId={`tabContent${0}`} />
+          <Tab eventKey={1} title={<TabTitleText>Clusters</TabTitleText>} tabContentId={`tabContent${1}`} />
+        </Tabs>
+      </PageSection>
+      <PageSection variant={PageSectionVariants.light}>
+        <TabContent key={0} eventKey={0} id={`tabContent${0}`} activeKey={activeTabKey} hidden={0 !== activeTabKey}>
+          <TabContentBody>{detailsTabContent}</TabContentBody>
+        </TabContent>
+        <TabContent key={1} eventKey={1} id={`tabContent${1}`} activeKey={activeTabKey} hidden={1 !== activeTabKey}>
+          <TabContentBody>{clustersTabContent}</TabContentBody>
+        </TabContent>
+      </PageSection>
+    </>
+  );
+};
+
+export default AccountsTabs;

--- a/src/app/AccountDetails/components/ClustersTable.tsx
+++ b/src/app/AccountDetails/components/ClustersTable.tsx
@@ -1,0 +1,42 @@
+import { renderStatusLabel } from '@app/utils/renderStatusLabel';
+import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { ClustersTableProps } from './types';
+
+const columnNames = {
+  id: 'ID',
+  name: 'Name',
+  status: 'Status',
+  cloudProvider: 'Cloud Provider',
+  instanceCount: 'Instance Count',
+};
+
+export const ClustersTable: React.FunctionComponent<ClustersTableProps> = ({ clusters }) => {
+  return (
+    <Table aria-label="Simple table">
+      <Thead>
+        <Tr>
+          <Th>{columnNames.id}</Th>
+          <Th>{columnNames.name}</Th>
+          <Th>{columnNames.status}</Th>
+          <Th>{columnNames.cloudProvider}</Th>
+          <Th>{columnNames.instanceCount}</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {clusters.map((cluster) => (
+          <Tr key={cluster.id}>
+            <Td dataLabel={cluster.name}>
+              <Link to={`/clusters/${cluster.id}`}>{cluster.id}</Link>
+            </Td>
+            <Td>{cluster.name}</Td>
+            <Td dataLabel={cluster.status}>{renderStatusLabel(cluster.status)}</Td>
+            <Td>{cluster.provider}</Td>
+            <Td>{cluster.instanceCount}</Td>
+          </Tr>
+        ))}
+      </Tbody>
+    </Table>
+  );
+};

--- a/src/app/AccountDetails/components/types.ts
+++ b/src/app/AccountDetails/components/types.ts
@@ -1,0 +1,25 @@
+import { AccountData, Cluster } from '@app/types/types';
+import React from 'react';
+
+export interface AccountsHeaderProps {
+  accountName: string;
+  label: string;
+}
+
+export interface AccountsTabsProps {
+  detailsTabContent: React.ReactNode;
+  clustersTabContent: React.ReactNode;
+}
+
+export interface AccountDetailsContentProps {
+  loading: boolean;
+  accountData: AccountData;
+}
+
+export interface AccountDescriptionListProps {
+  account: AccountData['accounts'][0];
+}
+
+export interface ClustersTableProps {
+  clusters: Cluster[];
+}

--- a/src/app/utils/debugLogs.ts
+++ b/src/app/utils/debugLogs.ts
@@ -1,0 +1,5 @@
+export const debug = (...args: unknown[]) => {
+  if (import.meta.env.DEV) {
+    console.log(...args);
+  }
+};

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": "./",
+    "types": ["vite/client"],
     "paths": {
       "@app/*": ["src/app/*"],
       "@assets/*": ["node_modules/@patternfly/react-core/dist/styles/assets/*"],


### PR DESCRIPTION
- Split AccountDetails into smaller, focused components
- Create dedicated components for header, tabs, description list
- Separate table logic into the `ClustersTable` component
- Move types to a dedicated file
- Add debug utility for development logs

Component structure:
- AccountDetails (main container)
- AccountsHeader (page header)
- AccountsTabs (tab navigation)
- AccountDetailsContent (details content)
- AccountDescriptionList (account info)
- AccountClusters (clusters container)
- ClustersTable (table display)