### PR TITLE
fix: use correct timestamp for 'Last scanned at' column in server details

### DIFF
--- a/src/app/ServerDetails/ServerDetails.tsx
+++ b/src/app/ServerDetails/ServerDetails.tsx
@@ -117,7 +117,7 @@ const ServerDetails: React.FunctionComponent = () => {
                 <LabelGroupOverflow labels={instanceData.instances[0].tags} />
                 <DescriptionListTerm>Last scanned at</DescriptionListTerm>
                 <DescriptionListDescription>
-                  {parseScanTimestamp(instanceData.instances[0].creationTimestamp)}
+                  {parseScanTimestamp(instanceData.instances[0].lastScanTimestamp)}
                 </DescriptionListDescription>
                 <DescriptionListTerm>Created at</DescriptionListTerm>
                 <DescriptionListDescription>


### PR DESCRIPTION
Use correct timestamp for `Last scanned at` column in server details