### PR TITLE
feat(overview): add total count display to Clusters and Instances tiles

### DIFF
--- a/src/app/Overview/Overview.tsx
+++ b/src/app/Overview/Overview.tsx
@@ -35,10 +35,9 @@ const AggregateStatusCards: React.FunctionComponent = () => {
       terminated: inventoryData?.clusters?.archived || 0,
     },
     instancesByStatus: {
-      running: 0, // Not available in current API
-      stopped: 0, // Not available in current API
-      unknown: 0, // Not available in current API
-      terminated: 0, // Not available in current API
+      running: inventoryData?.instances?.running || 0,
+      stopped: inventoryData?.instances?.stopped || 0,
+      terminated: inventoryData?.instances?.archived || 0,
     },
     clustersByProvider: {
       [CloudProvider.AWS]: inventoryData.providers.aws?.cluster_count || 0,
@@ -50,7 +49,7 @@ const AggregateStatusCards: React.FunctionComponent = () => {
       [CloudProvider.GCP]: inventoryData.providers.gcp?.account_count || 0,
       [CloudProvider.AZURE]: inventoryData.providers.azure?.account_count || 0,
     },
-    instances: inventoryData.instances.count,
+    instances: (inventoryData?.instances?.running || 0) + (inventoryData?.instances?.stopped || 0),
     lastScanTimestamp: inventoryData.scanner?.last_scan_timestamp,
   };
 
@@ -83,7 +82,7 @@ const AggregateStatusCards: React.FunctionComponent = () => {
                     ) : cards[0].customComponent ? (
                       cards[0].customComponent
                     ) : (
-                      renderContent(cards[0].content, cards[0].layout)
+                      renderContent(cards[0].content, cards[0].layout, cards[0].totalCount)
                     )}
                   </CardBody>
                 </Card>
@@ -100,7 +99,7 @@ const AggregateStatusCards: React.FunctionComponent = () => {
                   {cards.map((card, cardIndex) => (
                     <Card style={{ textAlign: 'center' }} key={`${groupIndex}${cardIndex}`} component="div">
                       <CardTitle>{card.title}</CardTitle>
-                      <CardBody>{renderContent(card.content, card.layout)}</CardBody>
+                      <CardBody>{renderContent(card.content, card.layout, card.totalCount)}</CardBody>
                     </Card>
                   ))}
                 </Gallery>

--- a/src/app/Overview/components/CardData.tsx
+++ b/src/app/Overview/components/CardData.tsx
@@ -1,5 +1,5 @@
 import { CardDefinition, CardLayout, DashboardState } from '../types';
-import { CLOUD_PROVIDERS, STATUSES } from '../constants';
+import { CLOUD_PROVIDERS, STATUSES, TOTAL_COUNT_ICONS } from '../constants';
 import { Event } from '@app/types/events';
 import { ActivityTable } from './ActivityTable';
 import React from 'react';
@@ -8,6 +8,9 @@ export const generateCards = (state: DashboardState, events: Event[] = []): Reco
   const scannerContent = state.lastScanTimestamp
     ? `${new Date(state.lastScanTimestamp).toLocaleString()}`
     : 'No scan data available';
+  const totalClusters = (state.clustersByStatus.running || 0) + (state.clustersByStatus.stopped || 0);
+  const totalInstances = state.instances || 0;
+
   const statusCards = [
     {
       title: 'Clusters',
@@ -17,6 +20,11 @@ export const generateCards = (state: DashboardState, events: Event[] = []): Reco
         ref: status.route,
       })),
       layout: CardLayout.MULTI_ICON,
+      totalCount: {
+        icon: TOTAL_COUNT_ICONS.clusters,
+        value: totalClusters,
+        label: 'Total',
+      },
     },
     {
       title: 'Instances',
@@ -26,6 +34,11 @@ export const generateCards = (state: DashboardState, events: Event[] = []): Reco
         ref: status.route,
       })),
       layout: CardLayout.MULTI_ICON,
+      totalCount: {
+        icon: TOTAL_COUNT_ICONS.instances,
+        value: totalInstances,
+        label: 'Total',
+      },
     },
     {
       title: 'Last Scan Timestamp',

--- a/src/app/Overview/components/CardRenderer.tsx
+++ b/src/app/Overview/components/CardRenderer.tsx
@@ -1,23 +1,38 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react';
-import { CardLayout } from '@app/Overview/types.ts';
+import { CardLayout, CardTotalCount } from '@app/Overview/types.ts';
 import { Divider, Flex, FlexItem, Stack } from '@patternfly/react-core';
 
 // TODO Avoid any
 export const RenderSingleIcon: React.FunctionComponent<{ content: any[] }> = ({ content }) => content[0]?.icon;
 // TODO Avoid any
-export const RenderMultiIcon: React.FunctionComponent<{ content: any[] }> = ({ content }) => (
-  <Flex display={{ default: 'inlineFlex' }}>
-    {content.map(({ icon, value, ref }, index) => (
-      <React.Fragment key={index}>
-        <Flex spaceItems={{ default: 'spaceItemsSm' }}>
-          <FlexItem>{icon}</FlexItem>
-          <FlexItem>{ref ? <a href={ref}>{value}</a> : <span>{value}</span>}</FlexItem>
-        </Flex>
-        {content.length > 1 && index < content.length - 1 && <Divider orientation={{ default: 'vertical' }} />}
-      </React.Fragment>
-    ))}
-  </Flex>
+export const RenderMultiIcon: React.FunctionComponent<{ content: any[]; totalCount?: CardTotalCount }> = ({
+  content,
+  totalCount,
+}) => (
+  <Stack hasGutter>
+    <Flex display={{ default: 'inlineFlex' }} justifyContent={{ default: 'justifyContentCenter' }}>
+      {content.map(({ icon, value, ref }, index) => (
+        <React.Fragment key={index}>
+          <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+            <FlexItem>{icon}</FlexItem>
+            <FlexItem>{ref ? <a href={ref}>{value}</a> : <span>{value}</span>}</FlexItem>
+          </Flex>
+          {content.length > 1 && index < content.length - 1 && <Divider orientation={{ default: 'vertical' }} />}
+        </React.Fragment>
+      ))}
+    </Flex>
+    {totalCount && (
+      <Flex justifyContent={{ default: 'justifyContentCenter' }} spaceItems={{ default: 'spaceItemsSm' }}>
+        <FlexItem>{totalCount.icon}</FlexItem>
+        <FlexItem>
+          <span style={{ fontWeight: 500 }}>
+            {totalCount.label}: {totalCount.value}
+          </span>
+        </FlexItem>
+      </Flex>
+    )}
+  </Stack>
 );
 // TODO Avoid any
 export const RenderWithSubtitle: React.FC<{ content: any[] }> = ({ content }) => (
@@ -34,12 +49,12 @@ export const RenderWithSubtitle: React.FC<{ content: any[] }> = ({ content }) =>
   </Flex>
 );
 // TODO Avoid any
-export const renderContent = (content: any[], layout: CardLayout) => {
+export const renderContent = (content: any[], layout: CardLayout, totalCount?: CardTotalCount) => {
   switch (layout) {
     case CardLayout.SINGLE_ICON:
       return <RenderSingleIcon content={content} />;
     case CardLayout.MULTI_ICON:
-      return <RenderMultiIcon content={content} />;
+      return <RenderMultiIcon content={content} totalCount={totalCount} />;
     case CardLayout.WITH_SUBTITLE:
       return <RenderWithSubtitle content={content} />;
   }

--- a/src/app/Overview/constants.tsx
+++ b/src/app/Overview/constants.tsx
@@ -9,6 +9,8 @@ import {
   GoogleIcon,
   AzureIcon,
   ArchiveIcon,
+  DatabaseIcon,
+  RegistryIcon,
 } from '@patternfly/react-icons';
 import { CloudProvider } from './types';
 
@@ -69,4 +71,9 @@ export const CLOUD_PROVIDERS = {
     icon: CLUSTER_ICON,
     providerIcon: PROVIDER_ICONS[CloudProvider.AZURE],
   },
+} as const;
+
+export const TOTAL_COUNT_ICONS = {
+  clusters: <DatabaseIcon color={PATTERNFLY_COLORS.disabled} />,
+  instances: <RegistryIcon color={PATTERNFLY_COLORS.disabled} />,
 } as const;

--- a/src/app/Overview/hooks/useDashboardData.ts
+++ b/src/app/Overview/hooks/useDashboardData.ts
@@ -14,7 +14,9 @@ interface InventoryData {
     archived: number;
   };
   instances: {
-    count: number;
+    running: number;
+    stopped: number;
+    archived: number;
   };
   providers: {
     aws: ProviderDetail;

--- a/src/app/Overview/types.ts
+++ b/src/app/Overview/types.ts
@@ -18,11 +18,18 @@ export interface CardContentItem {
   ref?: string;
 }
 
+export interface CardTotalCount {
+  icon: React.ReactNode;
+  value: number;
+  label: string;
+}
+
 export interface CardDefinition {
   title: string;
   content: CardContentItem[];
   layout: CardLayout;
   customComponent?: React.ReactNode;
+  totalCount?: CardTotalCount;
 }
 
 export interface DashboardState {


### PR DESCRIPTION
Add a new line on the Clusters and Instances tiles showing the total
count of elements with appropriate icons:
- DatabaseIcon for Clusters total
- RegistryIcon for Instances total