### PR TITLE
chore(deps): bump axios from 1.8.2 to 1.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@patternfly/react-styles": "^5.4.1",
     "@patternfly/react-table": "^5.4.12",
     "@types/react": "^19.0.1",
-    "axios": "^1.8.2",
+    "axios": "^1.12.0",
     "date-fns": "^4.1.0",
     "lodash.debounce": "4.0.8",
     "luxon": "^3.5.0",


### PR DESCRIPTION
Fix for https://github.com/RHEcosystemAppEng/cluster-iq-console/security/dependabot/56